### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AppInnovation-31571141/86378d61-0d96-4579-80a5-bd124db87c7e/574e10a3-b73f-466a-af3d-b740640a5173/_apis/work/boardbadge/f7ff6c52-6c43-4e40-b006-d1f4729e99dd)](https://dev.azure.com/AppInnovation-31571141/86378d61-0d96-4579-80a5-bd124db87c7e/_boards/board/t/574e10a3-b73f-466a-af3d-b740640a5173/Microsoft.RequirementCategory)
 # This project is retired, archived, and no longer supported. You are welcome to continue to use and fork the repository.
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#161](https://dev.azure.com/AppInnovation-31571141/86378d61-0d96-4579-80a5-bd124db87c7e/_workitems/edit/161). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.